### PR TITLE
container: create dockerfiles for micro services

### DIFF
--- a/cnap/userv/streaming.py
+++ b/cnap/userv/streaming.py
@@ -113,7 +113,7 @@ class StreamingService(MicroAppBase):
                 file_db_type = self.get_env("FILE_DB_TYPE", "local")
                 if file_db_type == "local":
                     self._provider.file_db = LocalFileDatabase(os.path.join(
-                            CURR_DIR, "../../sample-videos"))
+                            CURR_DIR, "../../demo/sample-videos"))
                 else:
                     # TODO: support other file database
                     LOG.error("Not supported file database type: %s", file_db_type)

--- a/container/cnap-inference/Dockerfile
+++ b/container/cnap-inference/Dockerfile
@@ -1,0 +1,50 @@
+FROM python:3.9-slim AS downloader
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/openvinotoolkit/open_model_zoo.git
+
+ARG pip_mirror
+
+RUN pip install ${pip_mirror} --upgrade --no-cache-dir pip && \
+    pip install ${pip_mirror} --no-cache-dir setuptools openvino-dev \
+    open_model_zoo/tools/model_tools
+
+RUN omz_downloader --name ssd_mobilenet_v1_coco
+
+FROM intel/oneapi-aikit:2023.1.1-devel-ubuntu22.04 AS runner
+
+RUN useradd --create-home appuser
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libopencv-dev && \
+    apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ARG pip_mirror
+
+COPY ./cnap /cnap
+
+COPY --from=downloader \
+    /public/ssd_mobilenet_v1_coco/ssd_mobilenet_v1_coco_2018_01_28/frozen_inference_graph.pb \
+    /demo/model/model.pb
+
+RUN chown -R appuser:appuser /demo /cnap
+
+ENV PYTHONPATH="/cnap:${PYTHONPATH}"
+
+RUN /opt/intel/oneapi/tensorflow/latest/bin/pip install ${pip_mirror} \
+    --upgrade --no-cache-dir pip \
+    && /opt/intel/oneapi/tensorflow/latest/bin/pip install ${pip_mirror} \
+    --no-cache-dir redis>=4.3.0 kafka-python websockets opencv-python
+
+RUN date > /build-date.cnap-inference.txt
+
+USER appuser
+
+CMD ["/opt/intel/oneapi/tensorflow/latest/bin/python", "/cnap/userv/inference.py"]

--- a/container/cnap-ppdb/Dockerfile
+++ b/container/cnap-ppdb/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.10-slim
+
+RUN useradd --create-home appuser
+
+COPY ./cnap /cnap
+
+RUN chown -R appuser:appuser /cnap
+
+ENV PYTHONPATH="/cnap:${PYTHONPATH}"
+
+ARG pip_mirror
+
+RUN pip3 install ${pip_mirror} --upgrade --no-cache-dir pip && \
+    pip3 install ${pip_mirror} --no-cache-dir flask flask_cors redis
+
+RUN date > /build-date.cnap-ppdb.txt
+
+EXPOSE 5000
+
+USER appuser
+
+CMD ["python", "/cnap/userv/pipeline_server.py"]

--- a/container/cnap-spa/Dockerfile
+++ b/container/cnap-spa/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:18-slim
+
+RUN useradd --create-home appuser
+
+COPY ./cnap /cnap
+
+RUN chown -R appuser:appuser /cnap && \
+    date > /build-date.cnap-spa.txt
+
+USER appuser
+
+WORKDIR /cnap/ui/
+
+RUN npm install --registry=https://registry.npmmirror.com
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev"]

--- a/container/cnap-streaming/Dockerfile
+++ b/container/cnap-streaming/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:22.04 AS downloader
+
+COPY ./tools /tools
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends unzip wget ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ./tools/video_downloader.sh
+
+FROM python:3.10-slim AS runner
+
+RUN useradd --create-home appuser
+
+COPY ./cnap /cnap
+
+COPY --from=downloader /sample-videos /demo/sample-videos
+
+RUN chown -R appuser:appuser /cnap /demo
+
+ENV PYTHONPATH="/cnap:${PYTHONPATH}"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libgl1-mesa-glx libglib2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG pip_mirror
+
+RUN pip3 install ${pip_mirror} --upgrade --no-cache-dir pip && \
+    pip3 install ${pip_mirror} --no-cache-dir redis numpy opencv-python kafka-python protobuf
+
+RUN date > /build-date.cnap-streaming.txt
+
+USER appuser
+
+CMD ["python", "/cnap/userv/streaming.py"]

--- a/container/cnap-wss/Dockerfile
+++ b/container/cnap-wss/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.10-slim
+
+RUN useradd --create-home appuser
+
+COPY ./cnap /cnap
+
+RUN chown -R appuser:appuser /cnap
+
+ENV PYTHONPATH="/cnap:${PYTHONPATH}"
+
+ARG pip_mirror
+
+RUN pip3 install ${pip_mirror} --upgrade --no-cache-dir pip && \
+    pip3 install ${pip_mirror} --no-cache-dir websockets redis>=4.3.0
+
+RUN date > /build-date.cnap-wss.txt
+
+EXPOSE 31611
+
+USER appuser
+
+CMD ["python", "/cnap/userv/websocket_server.py"]


### PR DESCRIPTION
This PR is to fix #77 , create dockerfiles for our micro services: streaming service, inference service, websocket server service, pipeline server service,  ui spa service.