### PR TITLE
cnap/core:add qat_zip to compress/decompress the frame

### DIFF
--- a/cnap/core/qat.py
+++ b/cnap/core/qat.py
@@ -1,0 +1,239 @@
+"""A QAT module.
+
+This module provides a class to use Intel qat to accelerate compression/decompression of frames.
+It provides methods to init, set up, teardown and close QATzip session, as well as compression 
+and decompression using QAT.
+
+Classes:
+    QATZip: A class that use QAT to accelerate frame compression and decompression.
+"""
+import ctypes
+import logging
+import time
+from core.qat_params import QzSession, QzSessionParamsCommon, QzSessionParamsDeflate
+
+LOG = logging.getLogger(__name__)
+qziplib = ctypes.cdll.LoadLibrary("libqatzip.so")
+
+
+class QATZip:
+    """A class that use QAT to accelerate frame compression and decompression..
+
+    Attributes:
+        _direction (int): The QATzip work way. 
+        _comp_lvl (int): The QATzip compression level.
+        _algorithm (int): The QATzip Compression/decompression algorithm.
+        _session (QzSession): The QATzip Session.
+        _common_session (QzSessionParamsCommon): The QATzip session with common parameters.
+        _deflate_params (QzSessionParamsDeflate): The QATzip session with deflate parameters.
+    """
+
+    #Enbale SW backup.
+    SW_BACKUP = 1
+    #No more data to be compressed.
+    LAST = 1
+    #Estimate maximum data expansion after decompression.
+    EXPANSION_RATIO = [5, 20, 50, 100]
+
+    #Session will be used for compression.
+    DIR_COMPRESS = 0
+    #Session will be used for decompression.
+    DIR_DECOMPRESS = 1
+    #Session will be used for both compression and decompression.
+    DIR_BOTH = 2
+
+    #Compression level - compress faster.
+    LEVEL_FAST = 1
+    #Compression level - compress better.
+    LEVEL_BEST = 9
+
+    #QATzip compression algorithm: deflate.
+    ALGO_DEFLATE = 8
+
+    def __init__(self,
+                 direction: int = DIR_BOTH,
+                 comp_lvl: int = LEVEL_FAST,
+                 algorithm: int = ALGO_DEFLATE):
+        """Initialize a QATzip object.
+
+        This constructor initializes a QATzip object with the given direction, compresion level 
+        and algorithm.
+
+        Args:
+            direction (int): The QATzip work way: DIR_COMPRESS, DIR_DECOMPRESS, or DIR_BOTH. 
+            comp_lvl (int): The QATzip compression level(from 1 to 9).
+            algorithm (int): The QATzip Compression/decompression algorithm(only ALGO_DEFLATE now).  
+        """
+        self._direction = direction
+        self._comp_lvl = comp_lvl
+        self._algorithm = algorithm
+        self._session = QzSession()
+        self._common_params = QzSessionParamsCommon(direction = ctypes.c_uint(self._direction),
+                                                    comp_lvl = ctypes.c_ubyte(self._comp_lvl),
+                                                    comp_algorithm = ctypes.c_uint(self._algorithm))
+        self._deflate_params = QzSessionParamsDeflate(common_params = self._common_params)
+        self.init_session()
+        self.set_session()
+
+    @property
+    def direction(self) -> int:
+        """int: Compress or decompress or both."""
+        return self._direction
+
+    @property
+    def comp_lvl(self) -> int:
+        """int: The QATzip compression level."""
+        return self._comp_lvl
+
+    @property
+    def algorithm(self) -> int:
+        """int: The QATzip compression/decompression algorithm."""
+        return self._algorithm
+
+    def init_session(self) -> None:
+        """Initialize QAT hardware.
+
+        Raises:
+            RuntimeError: If any errors during the initialization of QAT. 
+        """
+        ret = qziplib.qzInit(ctypes.byref(self._session), self.SW_BACKUP)
+        if ret != 0:
+            LOG.error("Failed to initialize the QATzip session: %s", ret)
+            raise RuntimeError(f"Initialize QATzip session failed with status:{ret}.")
+        LOG.info("Initialize QAT hardware successful.")
+
+    def set_session(self) -> None:
+        """Initialize a QATzip session with deflate parameters.
+        
+        Raises:
+            RuntimeError: If any error occurs during the session set up. 
+        """
+        ret = qziplib.qzSetupSessionDeflate(
+            ctypes.byref(self._session),
+            ctypes.byref(self._deflate_params))
+        if ret != 0:
+            LOG.error("Failed to setup the QATzip session: %s.", ret)
+            raise RuntimeError(f"Set QATzip session failed with status: {ret}.")
+        LOG.info("Set up QAT session successful.")
+
+    def teardown_session(self) -> None:
+        """Uninitialize a QATzip session.
+
+        This method disconnects a session from a hardware instance and deallocates buffers. 
+        If no session has been initialized, then no action will take place.
+        
+        Raises:
+            RuntimeError: If any error occurs during the session teardown. 
+        """
+        ret = qziplib.qzTeardownSession(ctypes.byref(self._session))
+        if ret != 0:
+            LOG.error("Failed to teardown the QATzip session: %s.", ret)
+            raise RuntimeError(f"Teardown the QATzip session failed with status: {ret}.")
+
+    def close_session(self) -> None:
+        """Terminates a QATzip session.
+        
+        This method closes the connection with QAT.
+        
+        Raises:
+            RuntimeError: If any error occurs while closing the session. 
+        """
+        ret = qziplib.qzClose(ctypes.byref(self._session))
+        if ret != 0:
+            LOG.error("Failed to close the QATzip session: %s.", ret)
+            raise RuntimeError(f"Close the QATzip session failed with status: {ret}.")
+
+    def compress(self, src: bytes) -> bytes:
+        """Use QAT to accelerate frame compression.
+
+        Args:
+            src (bytes): Frame that need to be compressed.
+
+        Returns:
+            bytes: Compressed Frame.
+        
+        Raises:
+            OverflowError: If compression integer overflow occurs.
+            ValueError: If the compression input length is invalid.
+            RuntimeError: If any error occurs during compression.
+        """
+        dst_sz = qziplib.qzMaxCompressedLength(len(src), ctypes.byref(self._session))
+        if dst_sz == 0:
+            LOG.error("Compression integer overflow happens.")
+            raise OverflowError("Compression integer overflow happens.")
+        if dst_sz == 34:
+            LOG.error("Compression input length is 0.")
+            raise ValueError("Invalid compression input length.")
+
+        #preprocessing: Convert src/dst to ctypes
+        src_len = ctypes.c_uint(len(src))
+        src_array = (ctypes.c_char * len(src))(*src)
+        src_point = ctypes.cast(ctypes.pointer(src_array),ctypes.c_void_p)
+
+        dst_len = ctypes.c_uint(dst_sz)
+        dst_bytes_array = (ctypes.c_char *dst_sz)()
+        dst_point = ctypes.cast(ctypes.pointer(dst_bytes_array), ctypes.c_void_p)
+
+        start_time = time.time()
+
+        ret = qziplib.qzCompress(
+            ctypes.byref(self._session),
+            src_point, ctypes.byref(src_len),
+            dst_point, ctypes.byref(dst_len),
+            self.LAST)
+        if ret != 0:
+            LOG.error("Failed to compress: %s.", ret)
+            raise RuntimeError(f"Compression failed with status: {ret}.")
+
+        end_time = time.time()
+        time_cost = end_time- start_time
+
+        LOG.debug("Compress %d bytes in %d bytes, cost %fs", len(src), dst_len.value, time_cost)
+        return bytes(dst_bytes_array.raw[:dst_len.value])
+
+    def decompress(self, src: bytes) -> bytes:
+        """Use QAT to accelerate frame decompression.
+
+        Args:
+            src (bytes): Frame that need to be decompressed.
+
+        Returns:
+            bytes: Decompressed Frame.
+        
+        Raises:
+            RuntimeError: If any error occurs during decompression. 
+        """
+        #preprocessing: Convert src/dst to ctypes
+        dst_sz =  len(src) * self.EXPANSION_RATIO[0]
+
+        src_len = ctypes.c_uint(len(src))
+        src_array = (ctypes.c_char * len(src))(*src)
+        src_point = ctypes.cast(ctypes.pointer(src_array),ctypes.c_void_p)
+
+        dst_len = ctypes.c_uint(dst_sz)
+        dst_bytes_array = (ctypes.c_char *dst_sz)()
+        dst_point = ctypes.cast(ctypes.pointer(dst_bytes_array), ctypes.c_void_p)
+
+        start_time = time.time()
+
+        ret = qziplib.qzDecompress(
+            ctypes.byref(self._session),
+            src_point, ctypes.byref(src_len),
+            dst_point, ctypes.byref(dst_len))
+        if ret != 0:
+            LOG.error("Failed to decompress: %s.", ret)
+            raise RuntimeError(f"Decompression failed with status: {ret}.")
+
+        end_time = time.time()
+        time_cost = end_time - start_time
+
+        LOG.debug("Decompress %d bytes in %d bytes, cost %fs", len(src), dst_len.value, time_cost)
+        return bytes(dst_bytes_array.raw[:dst_len.value])
+
+    def __del__(self):
+        """Ensure the release of each session."""
+        try:
+            self.teardown_session()
+            self.close_session()
+        except RuntimeError as e:
+            LOG.error("Error during releasing session: %s", e)

--- a/cnap/core/qat_params.py
+++ b/cnap/core/qat_params.py
@@ -1,0 +1,172 @@
+"""A QAT params module.
+
+This module provides the relevant parameters required to call QAT.
+
+Classes:
+    QzDirection: An enum for the type of the Huffman header supported by QATzip.
+    QzPollingMode: An enum for the type of polling mode supported by QATzip.
+    QzDataFormat: An enum for the type of data format supported by QATzip.
+    QzHuffmanHdr: An enum for the type of the Huffman header supported by QATzip.
+    QzSession:A class for QATzip Session opaque data storage.
+    QzSessionParamsCommon: A class for QATzip session common parameters.
+    QzSessionParamsDeflate: A class for QATzip session defalte parameters.
+"""
+
+import ctypes
+from enum import Enum
+
+class QzDirection(Enum):
+    """An enum for the type of QzDirection.
+    
+    This enum defines the types of QzDirection that can be created.
+    """
+
+    QZ_DIR_COMPRESS = ctypes.c_uint(0)
+    QZ_DIR_DECOMPRESS = ctypes.c_uint(1)
+    QZ_DIR_BOTH = ctypes.c_uint(2)
+
+class QzPollingMode(Enum):
+    """An enum for the type of QzPollingMode.
+    
+    This enum defines the types of polling mode supported by QATzip.
+    """
+
+    QZ_PERIODICAL_POLLING = ctypes.c_uint(0)
+    QZ_BUSY_POLLING = ctypes.c_uint(1)
+
+class QzDataFormat(Enum):
+    """An enum for the type of QzDataFormat.
+    
+    This enum defines the types of the data format supported by QATzip.
+    """
+
+    QZ_DEFLATE_4B = ctypes.c_uint(0)
+    QZ_DEFLATE_GZIP = ctypes.c_uint(1)
+    QZ_DEFLATE_GZIP_EXT = ctypes.c_uint(2)
+    QZ_DEFLATE_RAW = ctypes.c_uint(3)
+    QZ_FMT_NUM =  ctypes.c_uint(4)
+
+class QzHuffmanHdr(Enum):
+    """An enum for the type of QzipHuffmanHdr.
+    
+    This enum defines the types of the Huffman header supported by QATzip.
+    """
+
+    QZ_DYNAMIC_HDR = ctypes.c_uint(0)
+    QZ_STATIC_HDR = ctypes.c_uint(1)
+
+class QzSession(ctypes.Structure):
+    """A class for QATzip Session opaque data storage.
+    
+    This class contains a pointer to a structure with session state.
+    
+    Attributes:
+        hw_session_stat (ctypes.c_long): Hardware session status.
+        thd_sess_stst (ctypes.c_int): Note process compression and decompression thread state.
+        internel (ctypes.c_void_p): Session data is opaque to outside world.
+        total_in (ctypes.c_ulong): Total processed input data length in this session.
+        total_out(ctypes.c_ulong): Total output data length in this session.
+    """
+
+    _fields_ = [
+        ('hw_session_stat', ctypes.c_long),
+        ('thd_sess_stst', ctypes.c_int),
+        ('internel', ctypes.c_void_p),
+        ('total_in', ctypes.c_ulong),
+        ('total_out', ctypes.c_ulong),
+    ]
+
+    def __init__(self, **kwargs):
+        """Initialize the QzSession with default value."""
+        self.hw_session_stat = kwargs.get('hw_session_stat', 1)
+        self.thd_sess_stst = kwargs.get('thd_sess_stst', 0)
+        self.internel = kwargs.get('internel', None)
+        self.total_in = kwargs.get('total_in', 0)
+        self.total_out = kwargs.get('total_out', 0)
+
+class QzSessionParamsCommon(ctypes.Structure):
+    """A class for QATzip session common parameters.
+    
+    This structure contains data for initializing a common session..
+    
+    Attributes:
+        direction (ctypes.c_uint): Compress or decompress.
+        comp_lvl (ctypes.c_ubyte): Compression level 1 to 9.
+        comp_algorithm (ctypes.c_uint): Compress/decompression algorithms.
+        max_forks (ctypes.c_uint): Maximum forks permitted in the current thread.
+        sw_backup (ctypes.c_ubyte): Bit field defining SW configuration.
+        hw_buff_sz (ctypes.c_uint): Default buffer size, must be a power of 2k.
+        strm_buff_sz (ctypes.c_uint): Default strm_buf_sz, equals to hw_buff_sz.
+        input_sz_thrshold (ctypes.c_uint): Threshold of compression service's input size.
+        req_cnt_thrshold (ctypes.c_uint): Set between 1 and 32.
+        wait_cnt_thrshold (ctypes.c_uint): Wait for specific calls before device reopen retry.
+        polling_mode (ctypes.c_uint): Polling mode supported by QATzip.
+        is_sensitive_mode (ctypes.c_uint): 0 means disable sensitive mode, 1 means enable.
+    """
+
+    _fields_ = [
+        ('direction', ctypes.c_uint),
+        ('comp_lvl', ctypes.c_ubyte),
+        ('comp_algorithm', ctypes.c_uint),
+        ('max_forks', ctypes.c_uint),
+        ('sw_backup', ctypes.c_ubyte),
+        ('hw_buff_sz', ctypes.c_uint),
+        ('strm_buff_sz', ctypes.c_uint),
+        ('input_sz_thrshold', ctypes.c_uint),
+        ('req_cnt_thrshold', ctypes.c_uint),
+        ('wait_cnt_thrshold', ctypes.c_uint),
+        ('polling_mode',ctypes.c_uint),
+        ('is_sensitive_mode', ctypes.c_uint),
+    ]
+
+    def __init__(self,
+                direction: ctypes.c_uint = QzDirection.QZ_DIR_BOTH.value,
+                comp_lvl: ctypes.c_ubyte = 1,
+                comp_algorithm: ctypes.c_uint = 8,
+                max_forks: ctypes.c_uint = 2,
+                sw_backup: ctypes.c_ubyte = 1,
+                hw_buff_sz: ctypes.c_uint = 64*1024,
+                strm_buff_sz: ctypes.c_uint = 64*1024,
+                input_sz_thrshold: ctypes.c_uint = 1024,
+                req_cnt_thrshold: ctypes.c_uint = 32,
+                wait_cnt_thrshold: ctypes.c_uint = 8,
+                polling_mode: ctypes.c_uint = QzPollingMode.QZ_PERIODICAL_POLLING.value,
+                is_sensitive_mode: ctypes.c_uint = 0):
+        """Initialize the QzSessionParamsCommon with default value."""
+        self.direction = direction
+        self.comp_lvl = comp_lvl
+        self.comp_algorithm = comp_algorithm
+        self.max_forks = max_forks
+        self.sw_backup = sw_backup
+        self.hw_buff_sz = hw_buff_sz
+        self.strm_buff_sz = strm_buff_sz
+        self.input_sz_thrshold = input_sz_thrshold
+        self.req_cnt_thrshold = req_cnt_thrshold
+        self.wait_cnt_thrshold = wait_cnt_thrshold
+        self.polling_mode = polling_mode
+        self.is_sensitive_mode = is_sensitive_mode
+
+class QzSessionParamsDeflate(ctypes.Structure):
+    """A class for QATzip session deflate parameters.
+    
+    Attributes:
+        common_params (QzSessionParamsCommon): Compress or decompress. 
+        huffman_hdr (ctypes.c_uint): Dynamic or Static Huffman headers.
+        data_fmt (ctypes.c_uint): Deflate, deflate with GZip or deflate with GZip ext.
+               
+    """
+
+    _fields_ = [
+        ('common_params', QzSessionParamsCommon),
+        ('huffman_hdr',ctypes.c_uint),
+        ('data_fmt', ctypes.c_uint),
+    ]
+
+    def __init__(self,
+                common_params: QzSessionParamsCommon = QzSessionParamsCommon(),
+                huffman_hdr: QzHuffmanHdr = QzHuffmanHdr.QZ_DYNAMIC_HDR.value,
+                data_fmt: QzDataFormat = QzDataFormat.QZ_DEFLATE_GZIP.value):
+        """Initialize the QzSessionParamsDeflate with default value."""
+        self.common_params = common_params
+        self.huffman_hdr = huffman_hdr
+        self.data_fmt = data_fmt


### PR DESCRIPTION
This PR is to fix #91, and it depends on the Intel QAT driver and QATzip.

For usages examples:

#initialization
qat = QATFrameZip() 

#compression
compressed_data = qat.compress(frame_data)

#decompression
decompressed_data = qat.decompress(compressed_data)

#teardown&close
qat.teardown_session()
qat.close_session()