### PR TITLE
test_rtdb.py: add unit test for runtime database module.

### DIFF
--- a/cnap/requirements-test.txt
+++ b/cnap/requirements-test.txt
@@ -1,3 +1,3 @@
 pytest
 pytest-cov
-
+pytest-redis

--- a/tests/core/test_filedb.py
+++ b/tests/core/test_filedb.py
@@ -22,9 +22,6 @@ def test_local_file_database_get_file(tmp_path):
 
     Args:
         tmp_path (LocalPath): Temporary path provided by pytest's tmp_path fixture.
-
-    Returns:
-        None
     """
     # Create a temporary file for testing
     filename = 'test_file.txt'
@@ -36,28 +33,14 @@ def test_local_file_database_get_file(tmp_path):
     assert db.get_file(filename) == str(file_path)
 
 def test_local_file_database_get_file_invalid_root():
-    """Tests the get_file method of the LocalFileDatabase class with an invalid root directory.
-
-    Args:
-        None
-
-    Returns:
-        None
-    """
+    """Tests the get_file method of the LocalFileDatabase class with an invalid root directory."""
     root_dir = '/invalid/path'
     db = filedb.LocalFileDatabase(root_dir)
     with pytest.raises(FileNotFoundError):
         db.get_file('filename')
 
 def test_local_file_database_get_file_not_found(tmp_path):
-    """Tests the get_file method of the LocalFileDatabase class with a file not found.
-
-    Args:
-        tmp_path (LocalPath): Temporary path provided by pytest's tmp_path fixture.
-
-    Returns:
-        None
-    """
+    """Tests the get_file method of the LocalFileDatabase class with a file not found."""
     root_dir = str(tmp_path)
     db = filedb.LocalFileDatabase(root_dir)
     with pytest.raises(FileNotFoundError):

--- a/tests/core/test_frame.py
+++ b/tests/core/test_frame.py
@@ -51,9 +51,6 @@ TEST_FRAME_TIMESTAMP_SETTER = 1.1
 def img():
     """Fixture for raw image.
 
-    Args:
-        None
-
     Returns:
         numpy.ndarray: The raw image for test.
     """
@@ -64,9 +61,6 @@ def img():
 def filesource():
     """Fixture for Frame.
 
-    Args:
-        None
-
     Returns:
         StreamProvider: A `StreamProvider` object instantiated as `FileSource`.
     """
@@ -75,9 +69,6 @@ def filesource():
 @pytest.fixture
 def frame_instance(filesource, img):
     """Fixture for file source stream provider.
-
-    Args:
-        None
 
     Returns:
         StreamProvider: A `StreamProvider` object instantiated as `FileSource`.
@@ -89,9 +80,6 @@ def frame_instance(filesource, img):
 @pytest.fixture(scope="session")
 def expected_blob(img):
     """Fixture for expected blob bytes.
-
-    Args:
-        None
 
     Returns:
         bytes: The expected blob bytes for test.
@@ -113,9 +101,6 @@ def assert_frame_equal(frame1: frame.Frame, frame2: frame.Frame):
     Args:
         frame1 (Frame): The Frame to assert.
         frame2 (Frame): The Frame to assert.
-
-    Returns:
-        None
     """
     assert frame1.pipeline_id == frame2.pipeline_id
     assert frame1.sequence == frame2.sequence
@@ -128,9 +113,6 @@ def test_frame_pipeline_id_setter(frame_instance):
 
     Args:
         frame_instance (Frame): Fixture for Frame.
-
-    Returns:
-        None
     """
     frame_instance.pipeline_id = TEST_PIPELINE_ID_SETTER
     assert frame_instance.pipeline_id == TEST_PIPELINE_ID_SETTER
@@ -140,9 +122,6 @@ def test_frame_pipeline_timestamp_new_frame_setter(frame_instance):
 
     Args:
         frame_instance (Frame): Fixture for Frame.
-
-    Returns:
-        None
     """
     frame_instance.timestamp_new_frame = TEST_FRAME_TIMESTAMP_SETTER
     assert frame_instance.timestamp_new_frame == TEST_FRAME_TIMESTAMP_SETTER
@@ -152,9 +131,6 @@ def test_frame_pipeline_raw_setter(frame_instance):
 
     Args:
         frame_instance (Frame): Fixture for Frame.
-
-    Returns:
-        None
     """
     raw_setter = cv2.imread(os.path.join(CURR_DIR, "../../docs/cnap_uses.png"))
     frame_instance.raw = raw_setter
@@ -165,9 +141,6 @@ def test_frame_pipeline_timestamp_infer_start_setter(frame_instance):
 
     Args:
         frame_instance (Frame): Fixture for Frame.
-
-    Returns:
-        None
     """
     frame_instance.timestamp_infer_start = TEST_FRAME_TIMESTAMP_SETTER
     assert frame_instance.timestamp_infer_start == TEST_FRAME_TIMESTAMP_SETTER
@@ -180,9 +153,6 @@ def test_frame_to_blob(frame_instance, expected_blob):
     Args:
         frame_instance (Frame): Fixture for Frame.
         expected_blob (bytes): Fixture for expected blob bytes.
-
-    Returns:
-        None
     """
     blob = frame_instance.to_blob()
     assert blob == expected_blob
@@ -192,9 +162,6 @@ def test_frame_to_blob_failed(frame_instance):
 
     Args:
         frame_instance (Frame): Fixture for Frame.
-
-    Returns:
-        None
     """
     frame_instance = frame.Frame(filesource, TEST_PIPELINE_ID, 0x5fffffffffff00000000, img)
     with pytest.raises(RuntimeError):
@@ -208,9 +175,6 @@ def test_frame_from_blob(frame_instance, expected_blob):
     Args:
         frame_instance (Frame): Fixture for Frame.
         expected_blob (bytes): Fixture for expected blob bytes.
-
-    Returns:
-        None
     """
     restored_frame = frame.Frame.from_blob(expected_blob)
     assert_frame_equal(restored_frame, frame_instance)
@@ -220,19 +184,12 @@ def test_frame_from_blob_invalid_blob(frame_instance):
 
     Args:
         frame_instance (Frame): Fixture for Frame.
-
-    Returns:
-        None
     """
     with pytest.raises(TypeError):
         frame.Frame.from_blob(frame_instance)
 
 def test_frame_from_blob_failed():
-    """Tests the from_blob method of Frame class when deserializing fails.
-
-    Returns:
-        None
-    """
+    """Tests the from_blob method of Frame class when deserializing fails."""
     with pytest.raises(RuntimeError):
         frame.Frame.from_blob(b'0000000000000000000')
 
@@ -240,9 +197,6 @@ def test_frame_get_sequence():
     """Tests the get_sequence method of Frame class.
 
     This test checks if the get_sequence method can increase and reset the sequence correctly.
-
-    Returns:
-        None
     """
     assert frame.Frame.get_sequence() == frame.Frame.get_sequence() - 1
     frame.Frame.last_sequence = 0x7fffffffffff0001
@@ -255,9 +209,6 @@ def test_frame_normalize(frame_instance):
 
     Args:
         frame_instance (Frame): Fixture for Frame.
-
-    Returns:
-        None
     """
     frame_instance.normalize((TRAGET_WIDTH, TRAGET_HEIGHT))
     assert frame_instance.raw.shape == (TRAGET_WIDTH, TRAGET_HEIGHT, 3)
@@ -267,9 +218,6 @@ def test_frame_normalize_invalid_target_size(frame_instance):
 
     Args:
         frame_instance (Frame): Fixture for Frame.
-
-    Returns:
-        None
     """
     with pytest.raises(ValueError):
         frame_instance.normalize((-1, TRAGET_HEIGHT))

--- a/tests/core/test_infereng.py
+++ b/tests/core/test_infereng.py
@@ -11,12 +11,6 @@ def test_inference_engine():
 
     This test checks basic operations of the inference engine, including model loading, prediction,
     and error handling.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for the inference engine here
     assert True

--- a/tests/core/test_inferqueue.py
+++ b/tests/core/test_inferqueue.py
@@ -10,12 +10,6 @@ def test_inference_queue():
     """Tests the functionality of the inference queue.
 
     This test checks basic operations related to queuing and managing inference tasks.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for the inference queue here
     assert True

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -10,12 +10,6 @@ def test_metrics_framework():
     """Tests the functionality of the metrics framework.
 
     This test checks basic operations related to metrics collection, aggregation, and reporting.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for the metrics framework here
     assert True

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -10,12 +10,6 @@ def test_model_handling():
     """Tests the handling of models.
 
     This test checks basic operations related to model loading, manipulation, and management.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for model handling here
     assert True

--- a/tests/core/test_rtdb.py
+++ b/tests/core/test_rtdb.py
@@ -1,21 +1,351 @@
 """Tests for the runtime database.
 
-This module contains the tests for the runtime database.
+This module contains the tests for the runtime database module.
 
 Functions:
-    test_realtime_database: Tests the functionality of the real-time database.
+    rtdb_connect: Fixture for Redis runtime database.
+    data_config: Fixture for test data configurations.
+    test_redis_runtime_database_connect: Tests the connect method of the RedisDB class.
+    test_redis_runtime_database_connect_failed: Tests the connect method of the RedisDB class when
+      the connection fails.
+    test_redis_runtime_database_save_table_object_dict: Tests the save_table_object_dict method of
+      the RedisDB class.
+    test_redis_runtime_database_save_table_object_dict_failed: Tests the save_table_object_dict
+      method with the value can't be serialized into JSON.
+    test_redis_runtime_database_get_table_object_dict: Tests the get_table_object_dic method of the
+      RedisDB class.
+    test_redis_runtime_database_get_table_object_dict_not_found: Tests the get_table_object_dict
+      method of the RedisDB class when object not found.
+    test_redis_runtime_database_get_table_object_dict_json_decode_error: Tests the
+      get_table_object_dict method of the RedisDB class with json decode error of object.
+    test_redis_runtime_database_get_all_table_object_dict: Tests the get_all_table_object_dict
+      method of the RedisDB class.
+    test_redis_runtime_database_get_all_table_object_dict_not_found: Tests the
+      get_all_table_object_dict method of the RedisDB class when object not found.
+    test_redis_runtime_database_get_all_table_object_dict_json_decode_error: Tests the
+      get_all_table_object_dict method of the RedisDB class with json decode error.
+    test_redis_runtime_database_check_table_object_exist: Tests the check_table_object_exist method
+      of the RedisDB class.
+    test_redis_runtime_database_del_table_object: Tests the del_table_object method of the RedisDB
+      class.
+    test_invalid_table_param: Tests the methods of the RedisDB class with invalid table param.
+    test_invalid_obj_param: Tests the methods of the RedisDB class with invalid obj param.
 """
 
-def test_realtime_database():
-    """Tests the functionality of the real-time database.
+import json
 
-    This test checks basic operations related to real-time data handling and management.
+import pytest
+from pytest_redis import factories
+import redis.exceptions
+
+from cnap.core import rtdb
+
+# pylint: disable=redefined-outer-name
+
+REDIS_HOST = '0.0.0.0'
+REDIS_PORT = 8000
+
+my_redis_server = factories.redis_proc(host=REDIS_HOST, port=REDIS_PORT)
+my_redis_client = factories.redisdb('my_redis_server')
+
+@pytest.fixture
+def rtdb_connect(my_redis_client):
+    """Fixture for Redis runtime database.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+
+    Returns:
+        RuntimeDatabaseBase: A `RuntimeDatabaseBase` object.
+    """
+    db = rtdb.RedisDB()
+    db.connect(host=REDIS_HOST, port=REDIS_PORT)
+    return db
+
+@pytest.fixture
+def data_config():
+    """Fixture for test data configurations.
 
     Args:
         None
 
     Returns:
+        dict: A dict for test configurations.
+    """
+    config = {'table': 'test-table',
+              'obj': 'test-obj',
+              'dict': 'test-value'}
+    return config
+
+def test_redis_runtime_database_connect(my_redis_client, rtdb_connect):
+    """Tests the connect method of the RedisDB class.
+
+    This test checks if the connect method can connect to redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+
+    Returns:
         None
     """
-    # Add your specific tests for the real-time database here
-    assert True
+    assert my_redis_client.info()['connected_clients'] == 2
+
+def test_redis_runtime_database_connect_failed(my_redis_client):
+    """Tests the connect method of the RedisDB class when the connection fails.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+
+    Returns:
+        None
+    """
+    REDIS_PORT_WRONG = 8001
+    db = rtdb.RedisDB()
+    with pytest.raises(redis.exceptions.ConnectionError):
+        db.connect(host=REDIS_HOST, port=REDIS_PORT_WRONG)
+
+def test_redis_runtime_database_save_table_object_dict(my_redis_client, rtdb_connect, data_config):
+    """Tests the save_table_object_dict method of the RedisDB class.
+
+    This test checks if the save_table_object_dict method can save a dict value for an object in a
+    table on redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    rtdb_connect.save_table_object_dict(data_config['table'], data_config['obj'],
+                                        data_config['dict'])
+    assert my_redis_client.hget(data_config['table'], data_config['obj']) \
+            == json.dumps(data_config['dict']).encode()
+
+def test_redis_runtime_database_save_table_object_dict_failed(my_redis_client, rtdb_connect,
+                                                              data_config):
+    """Tests the save_table_object_dict method with the value can't be serialized into JSON.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+
+    with pytest.raises(TypeError):
+        rtdb_connect.save_table_object_dict(data_config['table'], data_config['obj'], rtdb_connect)
+
+def test_redis_runtime_database_get_table_object_dict(my_redis_client, rtdb_connect, data_config):
+    """Tests the get_table_object_dict method of the RedisDB class.
+
+    This test checks if the get_table_object_dic method can get a dict value for an object from a
+    table on redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    my_redis_client.hset(data_config['table'], data_config['obj'], json.dumps(data_config['dict']))
+    assert rtdb_connect.get_table_object_dict(data_config['table'], data_config['obj']) \
+            == data_config['dict']
+
+def test_redis_runtime_database_get_table_object_dict_not_found(my_redis_client, rtdb_connect,
+                                                             data_config):
+    """Tests the get_table_object_dict method of the RedisDB class when object not found.
+
+    This test checks if the get_table_object_dic method can get a dict value for an object from a
+    table on redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    assert rtdb_connect.get_table_object_dict(data_config['table'], data_config['obj']) == {}
+
+def test_redis_runtime_database_get_table_object_dict_json_decode_error(my_redis_client,
+                                                                        rtdb_connect, data_config):
+    """Tests the get_table_object_dict method of the RedisDB class with json decode error of object.
+
+    This test checks if the get_table_object_dic method can get a dict value for an object from a
+    table on redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    my_redis_client.hset(data_config['table'], data_config['obj'], data_config['dict'])
+    assert rtdb_connect.get_table_object_dict(data_config['table'], data_config['obj']) == {}
+
+def test_redis_runtime_database_get_all_table_object_dict(my_redis_client, rtdb_connect):
+    """Tests the get_all_table_object_dict method of the RedisDB class.
+
+    This test checks if the get_all_table_object_dict method can get all dict values from a table
+    on redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+
+    Returns:
+        None
+    """
+    table = 'test-table'
+    obj0 = 'test-obj0'
+    d0 = {'test-key0': 'test-value0'}
+    obj1 = 'test-obj1'
+    d1 = {'test-key1': 'test-value1'}
+
+    my_redis_client.hset(table, obj0, json.dumps(d0))
+    my_redis_client.hset(table, obj1, json.dumps(d1))
+    assert rtdb_connect.get_all_table_objects_dict(table) == {obj0: d0, obj1: d1}
+
+def test_redis_runtime_database_get_all_table_object_dict_not_found(my_redis_client, rtdb_connect,
+                                                                 data_config):
+    """Tests the get_all_table_object_dict method of the RedisDB class when object not found.
+
+    This test checks if the get_all_table_object_dict method can get all dict values from a table
+    on redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    assert rtdb_connect.get_all_table_objects_dict(data_config['table']) == {}
+
+def test_redis_runtime_database_get_all_table_object_dict_json_decode_error(
+        my_redis_client, rtdb_connect, data_config):
+    """Tests the get_all_table_object_dict method of the RedisDB class with json decode error.
+
+    This test checks if the get_all_table_object_dict method can get all dict values from a table
+    on redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    my_redis_client.hset(data_config['table'], data_config['obj'], data_config['dict'])
+    assert rtdb_connect.get_all_table_objects_dict(data_config['table']) == {}
+
+def test_redis_runtime_database_check_table_object_exist(my_redis_client, rtdb_connect,
+                                                         data_config):
+    """Tests the check_table_object_exist method of the RedisDB class.
+
+    This test checks if the check_table_object_exist method can check whether a given object exists
+    in a given table on redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    my_redis_client.hset(data_config['table'], data_config['obj'], json.dumps(data_config['dict']))
+    assert rtdb_connect.check_table_object_exist(data_config['table'], data_config['obj']) is True
+
+def test_redis_runtime_database_del_table_object(my_redis_client, rtdb_connect, data_config):
+    """Tests the del_table_object method of the RedisDB class.
+
+    This test checks if the del_table_object method can delete an object from a given table
+    on redis server successfully.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    my_redis_client.hset(data_config['table'], data_config['obj'], json.dumps(data_config['dict']))
+    rtdb_connect.del_table_object(data_config['table'], data_config['obj'])
+    assert my_redis_client.hexists(data_config['table'], data_config['obj']) is False
+
+def test_invalid_table_param(my_redis_client, rtdb_connect, data_config):
+    """Tests the methods of the RedisDB class with invalid table param.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    data_config['table'] = None
+
+    with pytest.raises(ValueError):
+        rtdb_connect.save_table_object_dict(data_config['table'], data_config['obj'],
+                                            data_config['dict'])
+    with pytest.raises(ValueError):
+        rtdb_connect.get_table_object_dict(data_config['table'], data_config['obj'])
+    with pytest.raises(ValueError):
+        rtdb_connect.get_all_table_objects_dict(data_config['table'])
+    with pytest.raises(ValueError):
+        rtdb_connect.check_table_object_exist(data_config['table'], data_config['obj'])
+    with pytest.raises(ValueError):
+        rtdb_connect.del_table_object(data_config['table'], data_config['obj'])
+
+def test_invalid_obj_param(my_redis_client, rtdb_connect, data_config):
+    """Tests the methods of the RedisDB class with invalid obj param.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+        rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
+        data_config (dict): Fixture for test data configurations.
+
+    Returns:
+        None
+    """
+    data_config['obj'] = None
+
+    with pytest.raises(ValueError):
+        rtdb_connect.save_table_object_dict(data_config['table'], data_config['obj'],
+                                            data_config['dict'])
+    with pytest.raises(ValueError):
+        rtdb_connect.get_table_object_dict(data_config['table'], data_config['obj'])
+    with pytest.raises(ValueError):
+        rtdb_connect.check_table_object_exist(data_config['table'], data_config['obj'])
+    with pytest.raises(ValueError):
+        rtdb_connect.del_table_object(data_config['table'], data_config['obj'])

--- a/tests/core/test_rtdb.py
+++ b/tests/core/test_rtdb.py
@@ -43,7 +43,7 @@ from cnap.core import rtdb
 # pylint: disable=redefined-outer-name
 
 REDIS_HOST = '0.0.0.0'
-REDIS_PORT = 8000
+REDIS_PORT = 8808
 
 my_redis_server = factories.redis_proc(host=REDIS_HOST, port=REDIS_PORT)
 my_redis_client = factories.redisdb('my_redis_server')
@@ -67,9 +67,6 @@ def rtdb_connect(my_redis_client):
 def data_config():
     """Fixture for test data configurations.
 
-    Args:
-        None
-
     Returns:
         dict: A dict for test configurations.
     """
@@ -87,9 +84,6 @@ def test_redis_runtime_database_connect(my_redis_client, rtdb_connect):
         my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
-
-    Returns:
-        None
     """
     assert my_redis_client.info()['connected_clients'] == 2
 
@@ -99,9 +93,6 @@ def test_redis_runtime_database_connect_failed(my_redis_client):
     Args:
         my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
           fixture.
-
-    Returns:
-        None
     """
     REDIS_PORT_WRONG = 8001
     db = rtdb.RedisDB()
@@ -119,9 +110,6 @@ def test_redis_runtime_database_save_table_object_dict(my_redis_client, rtdb_con
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     rtdb_connect.save_table_object_dict(data_config['table'], data_config['obj'],
                                         data_config['dict'])
@@ -137,9 +125,6 @@ def test_redis_runtime_database_save_table_object_dict_failed(my_redis_client, r
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
 
     with pytest.raises(TypeError):
@@ -156,9 +141,6 @@ def test_redis_runtime_database_get_table_object_dict(my_redis_client, rtdb_conn
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     my_redis_client.hset(data_config['table'], data_config['obj'], json.dumps(data_config['dict']))
     assert rtdb_connect.get_table_object_dict(data_config['table'], data_config['obj']) \
@@ -176,9 +158,6 @@ def test_redis_runtime_database_get_table_object_dict_not_found(my_redis_client,
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     assert rtdb_connect.get_table_object_dict(data_config['table'], data_config['obj']) == {}
 
@@ -194,9 +173,6 @@ def test_redis_runtime_database_get_table_object_dict_json_decode_error(my_redis
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     my_redis_client.hset(data_config['table'], data_config['obj'], data_config['dict'])
     assert rtdb_connect.get_table_object_dict(data_config['table'], data_config['obj']) == {}
@@ -211,9 +187,6 @@ def test_redis_runtime_database_get_all_table_object_dict(my_redis_client, rtdb_
         my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
-
-    Returns:
-        None
     """
     table = 'test-table'
     obj0 = 'test-obj0'
@@ -237,9 +210,6 @@ def test_redis_runtime_database_get_all_table_object_dict_not_found(my_redis_cli
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     assert rtdb_connect.get_all_table_objects_dict(data_config['table']) == {}
 
@@ -255,9 +225,6 @@ def test_redis_runtime_database_get_all_table_object_dict_json_decode_error(
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     my_redis_client.hset(data_config['table'], data_config['obj'], data_config['dict'])
     assert rtdb_connect.get_all_table_objects_dict(data_config['table']) == {}
@@ -274,9 +241,6 @@ def test_redis_runtime_database_check_table_object_exist(my_redis_client, rtdb_c
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     my_redis_client.hset(data_config['table'], data_config['obj'], json.dumps(data_config['dict']))
     assert rtdb_connect.check_table_object_exist(data_config['table'], data_config['obj']) is True
@@ -292,9 +256,6 @@ def test_redis_runtime_database_del_table_object(my_redis_client, rtdb_connect, 
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     my_redis_client.hset(data_config['table'], data_config['obj'], json.dumps(data_config['dict']))
     rtdb_connect.del_table_object(data_config['table'], data_config['obj'])
@@ -308,9 +269,6 @@ def test_invalid_table_param(my_redis_client, rtdb_connect, data_config):
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     data_config['table'] = None
 
@@ -334,9 +292,6 @@ def test_invalid_obj_param(my_redis_client, rtdb_connect, data_config):
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
         data_config (dict): Fixture for test data configurations.
-
-    Returns:
-        None
     """
     data_config['obj'] = None
 

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -10,12 +10,6 @@ def test_stream_handling():
     """Tests the handling of streams.
 
     This test checks basic operations related to stream manipulation and handling.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for stream handling here
     assert True

--- a/tests/core/test_streambroker.py
+++ b/tests/core/test_streambroker.py
@@ -10,12 +10,6 @@ def test_stream_broker():
     """Tests the functionality of the stream broker.
 
     This test checks basic operations related to stream brokering and management.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for the stream broker here
     assert True

--- a/tests/userv/test_inference.py
+++ b/tests/userv/test_inference.py
@@ -10,12 +10,6 @@ def test_inference_operations():
     """Tests the basic operations related to inference.
 
     This test checks functionalities such as model loading, prediction, and error handling.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for inference operations here
     assert True

--- a/tests/userv/test_pipeline_server.py
+++ b/tests/userv/test_pipeline_server.py
@@ -11,12 +11,6 @@ def test_pipeline_server_management():
 
     This test checks functionalities such as pipeline creation, modification, deletion, and
     execution.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for pipeline server management here
     assert True

--- a/tests/userv/test_streaming.py
+++ b/tests/userv/test_streaming.py
@@ -10,12 +10,6 @@ def test_streaming_functionality():
     """Tests the streaming functionalities.
 
     This test checks functionalities such as frame rate handling, quality control, and latency.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for streaming functionalities here
     assert True

--- a/tests/userv/test_uapp.py
+++ b/tests/userv/test_uapp.py
@@ -10,12 +10,6 @@ def test_user_application():
     """Tests the user application functionalities.
 
     This test checks functionalities related to user interactions, requests, and responses.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for user application functionalities here
     assert True

--- a/tests/userv/test_websocket_server.py
+++ b/tests/userv/test_websocket_server.py
@@ -11,12 +11,6 @@ def test_websocket_server():
 
     This test checks functionalities such as connection handling, message sending/receiving, and
     error management.
-
-    Args:
-        None
-
-    Returns:
-        None
     """
     # Add your specific tests for WebSocket server functionalities here
     assert True


### PR DESCRIPTION
This PR is to add unit test for runtime database module, it use [pytest-redis](https://pypi.org/project/pytest-redis/) to specify additional fixtures for Redis process and client.