### PR TITLE
.github/license_check.ini: update the authorized_licenses

### DIFF
--- a/.github/license_check.ini
+++ b/.github/license_check.ini
@@ -12,6 +12,7 @@ authorized_licenses:
         new bsd
         new bsd license
         simplified bsd
+        gnu lesser general public license v3 or later (lgplv3+)
         gnu lgpl
         isc license
         isc license (iscl)


### PR DESCRIPTION
This PR is to add `GNU Lesser General Public License v3 or later (LGPLv3+)` to authorized licenses, which will be detected for `pytest-redis`
```
mirakuru (2.5.1): ['GNU Lesser General Public License v3 or later (LGPLv3+)']
  dependency:
      mirakuru << pytest-redis
pytest-redis (3.0.2): ['GNU Lesser General Public License v3 or later (LGPLv3+)']
  dependency:
      pytest-redis
```