### PR TITLE
cicd: move coverage report to log

### DIFF
--- a/.github/workflows/pr-python-check.yaml
+++ b/.github/workflows/pr-python-check.yaml
@@ -57,11 +57,6 @@ jobs:
           export PYTHONPATH=$PWD/cnap:$PYTHONPATH
           python3 -m pytest --cov=cnap tests
 
-      - name: Generate XML coverage report
+      - name: Display detailed coverage report
         run: |
-          coverage xml
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
+          coverage report -m


### PR DESCRIPTION
This PR is to move the coverage report to log, avoid uploading to codecov