### PR TITLE
helm/inference: add deployment file for `service` and `servicemonitor`

### DIFF
--- a/helm/inference/templates/deployment.yaml
+++ b/helm/inference/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- toYaml .Values.env | nindent 10 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       initContainers:

--- a/helm/inference/templates/service.yaml
+++ b/helm/inference/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "inference.fullname" . }}-service
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "inference.selectorLabels" . | nindent 4 }}

--- a/helm/inference/templates/servicemonitor.yaml
+++ b/helm/inference/templates/servicemonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "inference.fullname" . }}
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "inference.selectorLabels" . | nindent 4 }}
+  endpoints:
+  - port: http
+    interval: 15s

--- a/helm/inference/values.yaml
+++ b/helm/inference/values.yaml
@@ -27,6 +27,10 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+service:
+  type: ClusterIP
+  port: 8000
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR is to fix #106 , add `service` and `servicemonitor` for inference deployment helm, so that Prometheus can scrape the metrics exported by inference service.
<img width="951" alt="image" src="https://github.com/intel/cloud-native-ai-pipeline/assets/108726629/27e38c76-50fc-4ebe-9fb5-f8d4c4bb49c9">
