### PR TITLE
helm: add matchLabels for sevicemonitor

### DIFF
--- a/helm/inference/templates/servicemonitor.yaml
+++ b/helm/inference/templates/servicemonitor.yaml
@@ -6,7 +6,8 @@ metadata:
     {{- include "inference.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "inference.selectorLabels" . | nindent 4 }}
+    matchLabels:
+      {{- include "inference.selectorLabels" . | nindent 6 }}
   endpoints:
   - port: http
     interval: 15s

--- a/helm/redis-exporter/templates/servicemonitor.yaml
+++ b/helm/redis-exporter/templates/servicemonitor.yaml
@@ -6,7 +6,8 @@ metadata:
     {{- include "redis-exporter.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "redis-exporter.selectorLabels" . | nindent 4 }}
+    matchLabels:
+      {{- include "redis-exporter.selectorLabels" . | nindent 6 }}
   endpoints:
   - port: http
     interval: 15s


### PR DESCRIPTION
This PR is to add `matchLabels` field for the selector of servicemonitor