### PR TITLE
ui: add real FPS data to the echarts on SPA

### DIFF
--- a/cnap/ui/src/components/DetailView.vue
+++ b/cnap/ui/src/components/DetailView.vue
@@ -79,7 +79,7 @@
     </el-col>
     <el-col :span="4">
       <div class="grid-content" >
-        <vue-echarts class="bar" :option="state2.overviewOption" ref="chart" style="height: 90%; width: 90%;"/>
+        <vue-echarts class="line" :option="getOption()" ref="chart" style="height: 90%; width: 90%;"/>
       </div>
     </el-col>
   </el-row>
@@ -89,6 +89,7 @@
 import { onMounted, reactive } from 'vue';
 import StreamView from './StreamView.vue';
 import { VueEcharts } from 'vue3-echarts';
+import type { EChartsOption } from 'echarts';
 
 const props = defineProps({
   pipeline_id: {
@@ -114,18 +115,61 @@ const props = defineProps({
   stream_url: {
     type: String,
     default: 'dummy url'
+  },
+  now_time: {
+    type: String,
+    default: ""
   }
 });
 
 const state = reactive({
-      overviewOption: {},
-      dataCenterTime: []
-    })
-
-const state2 = reactive({
   overviewOption: {},
   dataCenterTime: []
 })
+
+const max_points = 5;
+
+const data_source : Array<[string, number, number]>= [];
+
+function getOption() : EChartsOption {
+  data_source.push([props.now_time, props.infer_fps, Math.max(props.input_fps - props.infer_fps, 0)]);
+  if (data_source.length > max_points) {
+    data_source.splice(0, 1);
+  }
+
+  return {
+    legend: {},
+    tooltip: {},
+    dataset: {
+        dimensions:  ['product', 'Infer FPS', 'Drop FPS'],
+        source: data_source
+    },
+    color: ['#007bff', '#dc3545', '#007bff'],
+    xAxis: {
+        type: 'category',
+        axisTick: {
+            show: false
+        },
+    },
+    yAxis: {
+        show: true,
+        axisTick: {
+            show: false
+        },
+        axisLine: {
+            show: false
+        },
+        splitLine: {
+            show: true
+        },
+    },
+    series: [
+        {type: 'line'},
+        {type: 'line'},
+        {type: 'line'}
+    ]
+  }
+}
 
 onMounted(() => {
   state.overviewOption = {
@@ -162,45 +206,6 @@ onMounted(() => {
             {type: 'bar'},
             {type: 'bar'},
             {type: 'bar'}
-        ]
-    }
-
-  state2.overviewOption = {
-        legend: {},
-        tooltip: {},
-        dataset: {
-            dimensions:  ['product', 'Infer FPS', 'Drop FPS'],
-            source: [
-                ['1:00', 43.3, 85.8],
-                ['2:00', 83.1, 73.4],
-                ['3:00', 86.4, 65.2],
-                ['4:00', 72.4, 53.9],
-                ['5:00', 72.4, 53.9],
-          ]
-        },
-        color: ['#20c997', '#007bff', '#dc3545'],
-        xAxis: {
-            type: 'category',
-            axisTick: {
-                show: false
-            },
-        },
-        yAxis: {
-            show: true,
-            axisTick: {
-                show: false
-            },
-            axisLine: {
-                show: false
-            },
-            splitLine: {
-                show: true
-            },
-        },
-        series: [
-            {type: 'line'},
-            {type: 'line'},
-            {type: 'line'}
         ]
     }
 })

--- a/cnap/ui/src/store/index.ts
+++ b/cnap/ui/src/store/index.ts
@@ -62,13 +62,11 @@ export const refreshPipeline = async (pipeline_db_url:string, ws_server_url:stri
 }
 
 function format_time(date: Date) {
-  let hour = date.getHours();
-  let hour_string = hour >= 10 ? String(hour) : "0" + String(hour);
-  let minute = date.getMinutes();
-  let minute_string = minute >= 10 ? String(minute) : "0" + String(minute);
-  let second = date.getSeconds();
-  let second_string = second >= 10 ? String(second) : "0" + String(second);
-  return hour_string + ":" + minute_string + ":" + second_string;
+  const padZero = (num: number) => num < 10 ? `0${num}` : num.toString();
+  const hour = padZero(date.getHours());
+  const minute = padZero(date.getMinutes());
+  const second = padZero(date.getSeconds());
+  return `${hour}:${minute}:${second}`;
 }
 
 function get_env(key:string, default_vaule:any = null) {

--- a/cnap/ui/src/store/index.ts
+++ b/cnap/ui/src/store/index.ts
@@ -3,12 +3,13 @@ import { App } from 'vue'
 import { Pipeline } from '../api/ppdb_api';
 import axios  from "axios";
 
-const store = createStore<{pipelines:Pipeline[], stream_urls:string[],
+const store = createStore<{pipelines:Pipeline[], stream_urls:string[], now_time:string,
         pipeline_db_server:string, websocket_server:string}>({
   state() {
     return {
       pipelines: [],
       stream_urls: [],
+      now_time: "",
       // To prevent accidentally leaking env variables to the client, only variables prefixed
       // with `VITE_` are exposed to Vite-processed code.
       pipeline_db_server: 'http://' + get_env('VITE_PPDB_SERVER_HOST', window.location.hostname)
@@ -21,12 +22,14 @@ const store = createStore<{pipelines:Pipeline[], stream_urls:string[],
     updatePipelines(state, payload) {
       state.pipelines = payload.pipelines
       state.stream_urls = payload.urls
+      state.now_time = payload.now_time
       state.pipeline_db_server = payload.db_server
       state.websocket_server = payload.ws_server
     },
     cleanPipelines(state, payload) {
       state.pipelines = []
       state.stream_urls = []
+      state.now_time = ""
       state.pipeline_db_server = payload.db_server
       state.websocket_server = payload.ws_server
     }
@@ -45,13 +48,27 @@ export const refreshPipeline = async (pipeline_db_url:string, ws_server_url:stri
     for (let pipeline of res.data) {
       urls.push(ws_server_url + "/" + pipeline.pipeline_id);
     }
+
+    let date = new Date(Date.parse(new Date().toString()));
+    let now_time = format_time(date);
+
     store.commit('updatePipelines',
       {'db_server': pipeline_db_url, 'ws_server': ws_server_url,
-        'pipelines': res.data, 'urls': urls});
+        'pipelines': res.data, 'urls': urls, 'now_time': now_time});
   } catch (error) {
     console.log(error);
     store.commit('cleanPipelines', {'db_server': pipeline_db_url, 'ws_server': ws_server_url});
   }
+}
+
+function format_time(date: Date) {
+  let hour = date.getHours();
+  let hour_string = hour >= 10 ? String(hour) : "0" + String(hour);
+  let minute = date.getMinutes();
+  let minute_string = minute >= 10 ? String(minute) : "0" + String(minute);
+  let second = date.getSeconds();
+  let second_string = second >= 10 ? String(second) : "0" + String(second);
+  return hour_string + ":" + minute_string + ":" + second_string;
 }
 
 function get_env(key:string, default_vaule:any = null) {

--- a/cnap/ui/src/views/Pipelines.vue
+++ b/cnap/ui/src/views/Pipelines.vue
@@ -12,6 +12,7 @@
                 :input_fps="store.state.pipelines[index].input_fps"
                 :infer_fps="store.state.pipelines[index].infer_fps"
                 :stream_url="store.state.stream_urls[index]"
+                :now_time="store.state.now_time"
                 />
             </div>
           </el-card>


### PR DESCRIPTION
This PR is to fix #119 , add real FPS data to the echarts on SPA.

![spa](https://github.com/intel/cloud-native-ai-pipeline/assets/108726629/b40a2302-3fc9-4c34-8dd8-e3ccbf803c34)
