### PR TITLE
keda: add the keda scale job for inference based on drop fps

### DIFF
--- a/k8s-manifests/keda/infer_scale.yaml
+++ b/k8s-manifests/keda/infer_scale.yaml
@@ -1,0 +1,20 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ineference-scale
+  namespace: default
+spec:
+  scaleTargetRef:
+    name: inference
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  pollingInterval: 5 # Optional. Default: 30 seconds
+  cooldownPeriod:  30 # Optional. Default: 300 seconds
+  triggers:
+  - type: prometheus
+    metadata:
+      serverAddress: http://<prometheus-k8s-svc>
+      metricName: drop_fps
+      threshold: '5' # Define the threshold for scaling
+      query: sum(drop_fps) by (job)
+


### PR DESCRIPTION
This is to add the keda scale job based on inference drop fps, and example will increase the inference deployment replicas when sum drop fps larger than 5. 