### PR TITLE
keda: add the keda service monitor and update scale

### DIFF
--- a/k8s-manifests/keda/infer_scale.yaml
+++ b/k8s-manifests/keda/infer_scale.yaml
@@ -2,7 +2,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: ineference-scale
-  namespace: default
+  namespace: <cnap-inference-namespace>
 spec:
   scaleTargetRef:
     name: inference
@@ -15,6 +15,6 @@ spec:
     metadata:
       serverAddress: http://<prometheus-k8s-svc>
       metricName: drop_fps
-      threshold: '5' # Define the threshold for scaling
+      threshold: '10' # Define the threshold for scaling
       query: sum(drop_fps) by (job)
 

--- a/k8s-manifests/keda/keda-service-monitor.yaml
+++ b/k8s-manifests/keda/keda-service-monitor.yaml
@@ -1,0 +1,51 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: keda-metrics-apiserver-monitor
+  namespace: keda
+  labels:
+    app.kubernetes.io/name: keda-metrics-apiserver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keda-metrics-apiserver
+  endpoints:
+  - port: metrics
+    interval: 15s
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: keda-operator-monitor
+  namespace: keda
+  labels:
+    app.kubernetes.io/name: keda-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keda-operator
+  endpoints:
+  - port: metrics
+    interval: 15s
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: keda-admission-monitor
+  namespace: keda
+  labels:
+    app.kubernetes.io/component: admission-webhooks
+    app.kubernetes.io/instance: admission-webhooks
+    app.kubernetes.io/part-of: keda-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: admission-webhooks
+      app.kubernetes.io/instance: admission-webhooks
+      app.kubernetes.io/part-of: keda-operator
+  endpoints:
+  - port: metrics
+    interval: 15s
+


### PR DESCRIPTION
This PR is to add the Service Monitor CR to KEDA, which will expose its metrics to prometheus dashboard and also import the keda data to Grafana KEDA dashboard.