### PR TITLE
Prometheus: configure the prometheus to watch all namespace

### DIFF
--- a/k8s-manifests/prometheus/ClusterRole-All.yaml
+++ b/k8s-manifests/prometheus/ClusterRole-All.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get


### PR DESCRIPTION
This is an optional configuration for users to configure `prometheus` to get all namespace metrics exposed by pod/service.