### PR TITLE
test: add unit test for streambroker module

### DIFF
--- a/cnap/core/streambroker.py
+++ b/cnap/core/streambroker.py
@@ -38,7 +38,7 @@ class StreamBrokerClientBase(ABC):
     MAX_RECONNECTION_TIMES = 5
 
     @abstractmethod
-    def connect(self, host: str, port: int):
+    def connect(self, host: str, port: int): # pragma: no cover
         """Connect to broker server.
 
         This method is used to connect to stream broker server, will attempt to reconnect
@@ -54,7 +54,7 @@ class StreamBrokerClientBase(ABC):
         raise NotImplementedError("Subclasses should implement connect() method.")
 
     @abstractmethod
-    def publish_frame(self, topic: str, frame: Frame) -> None:
+    def publish_frame(self, topic: str, frame: Frame) -> None: # pragma: no cover
         """Publish a frame to stream broker server for a topic.
 
         Args:
@@ -143,10 +143,7 @@ class RedisStreamBrokerClient(StreamBrokerClientBase):
         except Exception as e:
             raise RuntimeError(f"Error during encoding image into jpg format: {str(e)}") from e
         frame.raw = img
-        try:
-            frame_blob = frame.to_blob()
-        except RuntimeError as e:
-            raise RuntimeError(e) from e
+        frame_blob = frame.to_blob()
         self._conn.publish(topic, frame_blob)
 
 
@@ -221,8 +218,5 @@ class KafkaStreamBrokerClient(StreamBrokerClientBase):
         except Exception as e:
             raise RuntimeError(f"Error during encoding image into jpg format: {str(e)}") from e
         frame.raw = img
-        try:
-            frame_blob = frame.to_blob()
-        except RuntimeError as e:
-            raise RuntimeError(e) from e
+        frame_blob = frame.to_blob()
         self._conn.send(topic, frame_blob)

--- a/cnap/requirements-test.txt
+++ b/cnap/requirements-test.txt
@@ -1,3 +1,4 @@
+docker
 pytest
 pytest-cov
 pytest-redis

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,125 @@
+"""Conftest module.
+
+This module contains the configurations for unit tests.
+
+Functions:
+    rtdb_connect: Fixture for Redis runtime database.
+    docker_client: Fixture for docker client.
+    network: Fixture for docker network.
+    kafka_broker: Fixture for kafka broker server.
+    img: Fixture for raw image.
+    filesource: Fixture for file source stream provider.
+    frame_instance: Fixture for Frame.
+"""
+
+import time
+import os
+
+import cv2
+import pytest
+from pytest_redis import factories
+import docker
+
+from cnap.core import frame, stream, rtdb
+
+# pylint: disable=no-member
+# pylint: disable=redefined-outer-name
+
+CURR_DIR = os.path.dirname(os.path.abspath(__file__))
+
+TEST_STREAM_NAME = 'classroom'
+TEST_PIPELINE_ID = '2bbbdebe-3722-11ee-ba4a-d6bcdc58bce0'
+TEST_FRAME_SEQUENCE = 0x5fffffffffff0000
+TEST_FRAME_TIMESTAMP = 0.0
+
+KAFKA_HOST = "localhost"
+KAFKA_PORT = 9092
+KAFKA_SERVER_START_TIME = 10
+
+REDIS_HOST = "localhost"
+REDIS_PORT = 8088
+
+my_redis_server = factories.redis_proc(host=REDIS_HOST, port=REDIS_PORT)
+my_redis_client = factories.redisdb('my_redis_server')
+
+@pytest.fixture
+def rtdb_connect(my_redis_client):
+    """Fixture for Redis runtime database.
+
+    Args:
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+
+    Returns:
+        RuntimeDatabaseBase: A `RuntimeDatabaseBase` object.
+    """
+    db = rtdb.RedisDB()
+    db.connect(host=REDIS_HOST, port=REDIS_PORT)
+    return db
+
+@pytest.fixture(scope="session")
+def docker_client():
+    """Fixture for docker client."""
+    return docker.from_env()
+
+@pytest.fixture(scope="session")
+def network(docker_client):
+    """Fixture for docker network."""
+    _network = docker_client.networks.create(name="network-test")
+    yield _network
+    _network.remove()
+
+@pytest.fixture(scope="session")
+def kafka_broker(docker_client, network):
+    """Fixture for kafka broker server."""
+    broker_container = docker_client.containers.run(
+        image="bitnami/kafka:latest",
+        ports={
+            f"{KAFKA_PORT}": f"{KAFKA_PORT}",
+        },
+        name="kafka-server",
+        hostname=KAFKA_HOST,
+        network=network.name,
+        environment={
+            "KAFKA_CFG_NODE_ID": 0,
+            "KAFKA_CFG_PROCESS_ROLES": "controller,broker",
+            "KAFKA_CFG_LISTENERS": f"PLAINTEXT://:{KAFKA_PORT},CONTROLLER://:{KAFKA_PORT + 1}",
+            "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP": "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT",
+            "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS": f"0@kafka-server:{KAFKA_PORT + 1}",
+            "KAFKA_CFG_CONTROLLER_LISTENER_NAMES": "CONTROLLER"
+        },
+        detach=True,
+    )
+    time.sleep(KAFKA_SERVER_START_TIME)
+    yield broker_container
+    broker_container.remove(force=True)
+
+@pytest.fixture(scope="session")
+def img():
+    """Fixture for raw image.
+
+    Returns:
+        numpy.ndarray: The raw image for test.
+    """
+    img = cv2.imread(os.path.join(CURR_DIR, "../../docs/cnap_arch.png"))
+    return img
+
+@pytest.fixture(scope="session")
+def filesource():
+    """Fixture for file source stream provider.
+
+    Returns:
+        StreamProvider: A `StreamProvider` object instantiated as `FileSource`.
+    """
+    return stream.FileSource(TEST_STREAM_NAME)
+
+@pytest.fixture
+def frame_instance(filesource, img):
+    """Fixture for Frame.
+
+    Returns:
+        Frame: A `Frame` object.
+    """
+    frame_instance = frame.Frame(filesource, TEST_PIPELINE_ID, TEST_FRAME_SEQUENCE, img)
+    frame_instance.timestamp_new_frame = TEST_FRAME_TIMESTAMP
+    return frame_instance

--- a/tests/core/test_frame.py
+++ b/tests/core/test_frame.py
@@ -3,9 +3,6 @@
 This module contains the tests for the frame module.
 
 Functions:
-    img: Fixture for raw image.
-    filesource: Fixture for Frame.
-    frame_instance: Fixture for file source stream provider.
     expected_blob: Fixture for expected blob bytes.
     assert_frame_equal: Assert if two frames are equal.
     test_frame_pipeline_id_setter: Tests the setter of _pipeline_id attribute of Frame class.
@@ -29,8 +26,9 @@ import os
 import cv2
 import pytest
 
-from cnap.core import frame, stream
+from cnap.core import frame
 from cnap.core.generated.core.protobuf import frame_pb2
+from tests.core.conftest import TEST_PIPELINE_ID, TEST_FRAME_TIMESTAMP, TEST_FRAME_SEQUENCE
 
 # pylint: disable=no-member
 # pylint: disable=redefined-outer-name
@@ -41,43 +39,10 @@ TRAGET_WIDTH = 300
 TRAGET_HEIGHT = 300
 
 TEST_STREAM_NAME = 'classroom'
-TEST_PIPELINE_ID = '2bbbdebe-3722-11ee-ba4a-d6bcdc58bce0'
 TEST_PIPELINE_ID_SETTER = '2bbbdebe-3722-11ee-ba4a-d6bcdc58bce1'
-TEST_FRAME_SEQUENCE = 0x5fffffffffff0000
-TEST_FRAME_TIMESTAMP = 0.0
 TEST_FRAME_TIMESTAMP_SETTER = 1.1
 
-@pytest.fixture(scope="session")
-def img():
-    """Fixture for raw image.
-
-    Returns:
-        numpy.ndarray: The raw image for test.
-    """
-    img = cv2.imread(os.path.join(CURR_DIR, "../../docs/cnap_arch.png"))
-    return img
-
-@pytest.fixture
-def filesource():
-    """Fixture for Frame.
-
-    Returns:
-        StreamProvider: A `StreamProvider` object instantiated as `FileSource`.
-    """
-    return stream.FileSource(TEST_STREAM_NAME)
-
-@pytest.fixture
-def frame_instance(filesource, img):
-    """Fixture for file source stream provider.
-
-    Returns:
-        StreamProvider: A `StreamProvider` object instantiated as `FileSource`.
-    """
-    frame_instance = frame.Frame(filesource, TEST_PIPELINE_ID, TEST_FRAME_SEQUENCE, img)
-    frame_instance.timestamp_new_frame = TEST_FRAME_TIMESTAMP
-    return frame_instance
-
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def expected_blob(img):
     """Fixture for expected blob bytes.
 
@@ -157,7 +122,7 @@ def test_frame_to_blob(frame_instance, expected_blob):
     blob = frame_instance.to_blob()
     assert blob == expected_blob
 
-def test_frame_to_blob_failed(frame_instance):
+def test_frame_to_blob_failed(frame_instance, img, filesource):
     """Tests the to_blob method of Frame class when serializing fails.
 
     Args:

--- a/tests/core/test_infereng.py
+++ b/tests/core/test_infereng.py
@@ -4,7 +4,6 @@ This module contains the tests for the inference engine module.
 
 Functions:
     inference_info: Fixture for inference info.
-    rtdb_connect: Fixture for Redis runtime database.
     inference_engine_manager: Fixture for inference engine manager.
     model_info: Fixture for model info.
     assert_inference_info_equal: Assert if two inference info are equal.
@@ -33,9 +32,8 @@ Functions:
 import uuid
 
 import pytest
-from pytest_redis import factories
 
-from cnap.core import infereng, model, rtdb
+from cnap.core import infereng, model
 
 # pylint: disable=redefined-outer-name
 
@@ -48,12 +46,6 @@ TEST_MODEL_NAME = 'ssdmobilenet'
 TEST_MODEL_PATH = '/tmp/ssdmobilenet_v10.pb'
 TEST_MODEL_VERSION = '1.0'
 
-REDIS_HOST = '0.0.0.0'
-REDIS_PORT = 8080
-
-my_redis_server = factories.redis_proc(host=REDIS_HOST, port=REDIS_PORT)
-my_redis_client = factories.redisdb('my_redis_server')
-
 @pytest.fixture
 def inference_info():
     """Fixture for inference info.
@@ -62,21 +54,6 @@ def inference_info():
         InferenceInfo: A `InferenceInfo` object.
     """
     return infereng.InferenceInfo(TEST_DEVICE, TEST_MODEL_ID)
-
-@pytest.fixture
-def rtdb_connect(my_redis_client):
-    """Fixture for Redis runtime database.
-
-    Args:
-        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
-          fixture.
-
-    Returns:
-        RuntimeDatabaseBase: A `RuntimeDatabaseBase` object.
-    """
-    db = rtdb.RedisDB()
-    db.connect(host=REDIS_HOST, port=REDIS_PORT)
-    return db
 
 @pytest.fixture
 def inference_engine_manager(rtdb_connect):

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -3,10 +3,8 @@
 This module contains the tests for the pipeline module.
 
 Functions:
-    filesource: Fixture for file source stream provider.
     inference_info: Fixture for inference info.
     pipeline_instance: Fixture for pipeline.
-    rtdb_connect: Fixture for Redis runtime database.
     pipeline_manager: Fixture for pipeline manager.
     test_pipeline_id_setter: Tests the setter of _id attribute of Pipeline class.
     test_pipeline_iter: Tests the Iterator of Pipeline class.
@@ -24,9 +22,8 @@ import uuid
 import json
 
 import pytest
-from pytest_redis import factories
 
-from cnap.core import infereng, pipeline, rtdb, stream
+from cnap.core import infereng, pipeline, stream
 
 # pylint: disable=redefined-outer-name
 
@@ -34,12 +31,6 @@ TEST_STREAM_NAME = 'classroom'
 TEST_DEVICE = 'cpu'
 TEST_MODEL_ID = str(uuid.uuid1())
 TEST_PIPELINE_ID = "2bbbdebe-3722-11ee-ba4a-d6bcdc58bce0"
-
-REDIS_HOST = '0.0.0.0'
-REDIS_PORT = 8000
-
-my_redis_server = factories.redis_proc(host=REDIS_HOST, port=REDIS_PORT)
-my_redis_client = factories.redisdb('my_redis_server')
 
 @pytest.fixture
 def filesource():
@@ -71,21 +62,6 @@ def pipeline_instance(filesource, inference_info):
         Pipeline: A `Pipeline` object.
     """
     return pipeline.Pipeline(filesource, inference_info)
-
-@pytest.fixture
-def rtdb_connect(my_redis_client):
-    """Fixture for Redis runtime database.
-
-    Args:
-        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
-          fixture.
-
-    Returns:
-        RuntimeDatabaseBase: A `RuntimeDatabaseBase` object.
-    """
-    db = rtdb.RedisDB()
-    db.connect(host=REDIS_HOST, port=REDIS_PORT)
-    return db
 
 @pytest.fixture
 def pipeline_manager(rtdb_connect):

--- a/tests/core/test_rtdb.py
+++ b/tests/core/test_rtdb.py
@@ -3,7 +3,6 @@
 This module contains the tests for the runtime database module.
 
 Functions:
-    rtdb_connect: Fixture for Redis runtime database.
     data_config: Fixture for test data configurations.
     test_redis_runtime_database_connect: Tests the connect method of the RedisDB class.
     test_redis_runtime_database_connect_failed: Tests the connect method of the RedisDB class when
@@ -35,33 +34,12 @@ Functions:
 import json
 
 import pytest
-from pytest_redis import factories
 import redis.exceptions
 
 from cnap.core import rtdb
+from tests.core.conftest import REDIS_HOST
 
 # pylint: disable=redefined-outer-name
-
-REDIS_HOST = '0.0.0.0'
-REDIS_PORT = 8808
-
-my_redis_server = factories.redis_proc(host=REDIS_HOST, port=REDIS_PORT)
-my_redis_client = factories.redisdb('my_redis_server')
-
-@pytest.fixture
-def rtdb_connect(my_redis_client):
-    """Fixture for Redis runtime database.
-
-    Args:
-        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
-          fixture.
-
-    Returns:
-        RuntimeDatabaseBase: A `RuntimeDatabaseBase` object.
-    """
-    db = rtdb.RedisDB()
-    db.connect(host=REDIS_HOST, port=REDIS_PORT)
-    return db
 
 @pytest.fixture
 def data_config():
@@ -75,7 +53,7 @@ def data_config():
               'dict': 'test-value'}
     return config
 
-def test_redis_runtime_database_connect(my_redis_client, rtdb_connect):
+def test_redis_runtime_database_connect(rtdb_connect):
     """Tests the connect method of the RedisDB class.
 
     This test checks if the connect method can connect to redis server successfully.
@@ -85,7 +63,7 @@ def test_redis_runtime_database_connect(my_redis_client, rtdb_connect):
           fixture.
         rtdb_connect (RuntimeDatabaseBase): Fixture for Redis runtime database.
     """
-    assert my_redis_client.info()['connected_clients'] == 2
+    assert rtdb_connect._conn.ping() # pylint: disable=protected-access
 
 def test_redis_runtime_database_connect_failed(my_redis_client):
     """Tests the connect method of the RedisDB class when the connection fails.

--- a/tests/core/test_streambroker.py
+++ b/tests/core/test_streambroker.py
@@ -3,13 +3,190 @@
 This module contains the tests for the stream broker.
 
 Functions:
-    test_stream_broker: Tests the functionality of the stream broker.
+    redis_broker_client: Fixture for Redis Streambroker client.
+    kafka_broker_client: Fixture for Kafka Streambroker client.
+    test_redis_stream_broker_client_connect: Tests the connect method of the RedisStreamBrokerClient
+      class.
+    test_redis_stream_broker_client_connect_failed: Tests the connect method of the
+      RedisStreamBrokerClient class when the connection fails.
+    test_redis_stream_broker_client_publish_frame: Tests the publish_frame method of the
+      RedisStreamBrokerClient class.
+    test_kafka_stream_broker_client_connect: Tests the connect method of the KafkaStreamBrokerClient
+      class.
+    test_kafka_stream_broker_client_connect_failed: Tests the connect method of the
+      KafkaStreamBrokerClient class when the connection fails.
+    test_kafka_stream_broker_client_publish_frame: Tests the publish_frame method of the
+      KafkaStreamBrokerClient class.
+    test_publish_frame_invalid_topic: Tests the publish_frame method with invalid topic.
+    test_publish_frame_invalid_frame: Tests the publish_frame method with invalid frame.
+    test_publish_frame_error_encode: Tests the publish_frame method when encoding error.
 """
 
-def test_stream_broker():
-    """Tests the functionality of the stream broker.
+import pytest
+import redis.exceptions
+from kafka import KafkaConsumer
+import kafka.errors
+import cv2
 
-    This test checks basic operations related to stream brokering and management.
+from cnap.core import streambroker
+from tests.core.conftest import TEST_PIPELINE_ID, KAFKA_HOST, KAFKA_PORT, REDIS_HOST, REDIS_PORT
+
+TEST_TOPIC = f"result-{TEST_PIPELINE_ID}"
+
+# pylint: disable=no-member
+# pylint: disable=redefined-outer-name
+
+@pytest.fixture(scope="module")
+def redis_broker_client(my_redis_server):
+    """Fixture for Redis Streambroker client.
+
+    Args:
+        my_redis_server (Callable): Temporary redis server provided by pytest-redis's redisdb
+          fixture.
+
+    Returns:
+        RedisStreamBrokerClient: A `RedisStreamBrokerClient` object.
     """
-    # Add your specific tests for the stream broker here
-    assert True
+    broker_conn = streambroker.RedisStreamBrokerClient()
+    broker_conn.connect(host=REDIS_HOST, port=REDIS_PORT)
+    return broker_conn
+
+@pytest.fixture(scope="module")
+def kafka_broker_client(kafka_broker):
+    """Fixture for Kafka Streambroker client.
+
+    Args:
+        kafka_broker (Container): Fixture for kafka broker server.
+
+    Returns:
+        KafkaStreamBrokerClient: A `KafkaStreamBrokerClient` object.
+    """
+    broker_client = streambroker.KafkaStreamBrokerClient()
+    broker_client.connect(host=KAFKA_HOST, port=KAFKA_PORT)
+    return broker_client
+
+def test_redis_stream_broker_client_connect(redis_broker_client):
+    """Tests the connect method of the RedisStreamBrokerClient class.
+
+    This test checks if the connect method can connect to redis server successfully.
+
+    Args:
+        redis_broker_client (RedisStreamBrokerClient): Fixture for RedisStreamBrokerClient.
+    """
+    assert redis_broker_client._conn.ping() # pylint: disable=protected-access
+
+def test_redis_stream_broker_client_connect_failed(my_redis_server):
+    """Tests the connect method of the RedisStreamBrokerClient class when the connection fails.
+
+    Args:
+        my_redis_server (Callable): Temporary redis server provided by pytest-redis's redisdb
+          fixture.
+    """
+    REDIS_PORT_WRONG = 8001
+    broker_client = streambroker.RedisStreamBrokerClient()
+    with pytest.raises(redis.exceptions.ConnectionError):
+        broker_client.connect(host=REDIS_HOST, port=REDIS_PORT_WRONG)
+
+def test_redis_stream_broker_client_publish_frame(redis_broker_client, frame_instance,
+                                                  my_redis_client):
+    """Tests the publish_frame method of the RedisStreamBrokerClient class.
+
+    This test checks if the publish_frame method can publish frame to redis server successfully.
+
+    Args:
+        redis_broker_client (RedisStreamBrokerClient): Fixture for RedisStreamBrokerClient.
+        frame_instance (Frame): Fixture for Frame.
+        my_redis_client (Callable): Temporary redis client provided by pytest-redis's redisdb
+          fixture.
+    """
+    pubsub = my_redis_client.pubsub()
+    pubsub.subscribe(TEST_TOPIC)
+    response = pubsub.handle_message(pubsub.parse_response())
+    assert response is not None and response['type'] == 'subscribe'
+
+    redis_broker_client.publish_frame(TEST_TOPIC, frame_instance)
+
+    response = pubsub.handle_message(pubsub.parse_response())
+    assert response is not None and response['type'] == 'message'
+    assert response['data'] == frame_instance.to_blob()
+
+def test_kafka_stream_broker_client_connect(kafka_broker_client):
+    """Tests the connect method of the KafkaStreamBrokerClient class.
+
+    This test checks if the connect method can connect to redis server successfully.
+
+    Args:
+        kafka_broker_client (KafkaStreamBrokerClient): Fixture for KafkaStreamBrokerClient.
+    """
+    assert kafka_broker_client._conn.bootstrap_connected() # pylint: disable=protected-access
+
+def test_kafka_stream_broker_client_connect_failed(kafka_broker):
+    """Tests the connect method of the KafkaStreamBrokerClient class when the connection fails.
+
+    Args:
+        kafka_broker (Container): Fixture for kafka broker server.
+    """
+    KAFKA_PORT_WRONG = 9001
+    broker_client = streambroker.KafkaStreamBrokerClient()
+    with pytest.raises(kafka.errors.NoBrokersAvailable):
+        broker_client.connect(host=KAFKA_HOST, port=KAFKA_PORT_WRONG)
+
+def test_kafka_stream_broker_client_publish_frame(kafka_broker_client, frame_instance):
+    """Tests the publish_frame method of the KafkaStreamBrokerClient class.
+
+    This test checks if the publish_frame method can publish frame to kafka server successfully.
+
+    Args:
+        kafka_broker_client (KafkaStreamBrokerClient): Fixture for KafkaStreamBrokerClient.
+        frame_instance (Frame): Fixture for Frame.
+    """
+    consumer = KafkaConsumer(TEST_TOPIC, group_id='test2',
+                             bootstrap_servers=f"{KAFKA_HOST}:{KAFKA_PORT}",
+                             auto_offset_reset='earliest', enable_auto_commit=False)
+    assert consumer.bootstrap_connected()
+
+    kafka_broker_client.publish_frame(TEST_TOPIC, frame_instance)
+
+    for message in consumer:
+        assert message.value == frame_instance.to_blob()
+        break
+
+def test_publish_frame_invalid_topic(redis_broker_client, kafka_broker_client, frame_instance):
+    """Tests the publish_frame method with invalid topic.
+
+    Args:
+        redis_broker_client (RedisStreamBrokerClient): Fixture for RedisStreamBrokerClient.
+        kafka_broker_client (KafkaStreamBrokerClient): Fixture for KafkaStreamBrokerClient.
+        frame_instance (Frame): Fixture for Frame.
+    """
+    with pytest.raises(ValueError):
+        redis_broker_client.publish_frame(None, frame_instance)
+    with pytest.raises(ValueError):
+        kafka_broker_client.publish_frame(None, frame_instance)
+
+def test_publish_frame_invalid_frame(redis_broker_client, kafka_broker_client):
+    """Tests the publish_frame method with invalid frame.
+
+    Args:
+        redis_broker_client (RedisStreamBrokerClient): Fixture for RedisStreamBrokerClient.
+        kafka_broker_client (KafkaStreamBrokerClient): Fixture for KafkaStreamBrokerClient.
+    """
+    with pytest.raises(ValueError):
+        redis_broker_client.publish_frame(TEST_TOPIC, None)
+    with pytest.raises(ValueError):
+        kafka_broker_client.publish_frame(TEST_TOPIC, None)
+
+def test_publish_frame_error_encode(redis_broker_client, kafka_broker_client, frame_instance):
+    """Tests the publish_frame method when encoding error.
+
+    Args:
+        redis_broker_client (RedisStreamBrokerClient): Fixture for RedisStreamBrokerClient.
+        kafka_broker_client (KafkaStreamBrokerClient): Fixture for KafkaStreamBrokerClient.
+        frame_instance (Frame): Fixture for Frame.
+    """
+    _, img = cv2.imencode('.jpg', frame_instance.raw)
+    frame_instance.raw = img
+    with pytest.raises(RuntimeError):
+        redis_broker_client.publish_frame(TEST_TOPIC, frame_instance)
+    with pytest.raises(RuntimeError):
+        kafka_broker_client.publish_frame(TEST_TOPIC, frame_instance)


### PR DESCRIPTION
- add conftest.py for configurations and fixtures
- move shared fixtures to conftest.py
- use docker sdk for python to run kafka server for test