### PR TITLE
container: update inference dockerfile for new model design

### DIFF
--- a/container/cnap-inference/Dockerfile
+++ b/container/cnap-inference/Dockerfile
@@ -1,21 +1,3 @@
-FROM python:3.9-slim AS downloader
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://github.com/openvinotoolkit/open_model_zoo.git
-
-ARG pip_mirror
-
-RUN pip install ${pip_mirror} --upgrade --no-cache-dir pip && \
-    pip install ${pip_mirror} --no-cache-dir setuptools openvino-dev \
-    open_model_zoo/tools/model_tools
-
-RUN omz_downloader --name ssd_mobilenet_v1_coco
-
 FROM intel/oneapi-aikit:2023.1.1-devel-ubuntu22.04 AS runner
 
 RUN useradd --create-home appuser
@@ -30,18 +12,15 @@ ARG pip_mirror
 
 COPY ./cnap /cnap
 
-COPY --from=downloader \
-    /public/ssd_mobilenet_v1_coco/ssd_mobilenet_v1_coco_2018_01_28/frozen_inference_graph.pb \
-    /demo/model/model.pb
-
-RUN chown -R appuser:appuser /demo /cnap
+RUN chown -R appuser:appuser /cnap
 
 ENV PYTHONPATH="/cnap:${PYTHONPATH}"
 
 RUN /opt/intel/oneapi/tensorflow/latest/bin/pip install ${pip_mirror} \
     --upgrade --no-cache-dir pip \
     && /opt/intel/oneapi/tensorflow/latest/bin/pip install ${pip_mirror} \
-    --no-cache-dir redis>=4.3.0 kafka-python websockets opencv-python prometheus_client
+    --no-cache-dir redis>=4.3.0 kafka-python websockets opencv-python prometheus_client \
+    ccnp requests
 
 RUN date > /build-date.cnap-inference.txt
 

--- a/helm/inference/values.yaml
+++ b/helm/inference/values.yaml
@@ -66,16 +66,14 @@ env:
     value: "redis"
   - name: BROKER_HOST
     value: "redis-service"
-  - name: INFER_FRAMEWORK
-    value: "tensorflow"
-  - name: INFER_TARGET
-    value: "object-detection"
+  - name: INFER_MODEL_PROVIDER
+    value: "simple"
+  - name: INFER_MODEL_INFO_URL
+    value: ""
+  - name: INFER_MODEL_ID
+    value: ""
   - name: INFER_DEVICE
     value: "cpu"
-  - name: INFER_MODEL_NAME
-    value: "ssdmobilenet"
-  - name: INFER_MODEL_VERSION
-    value: "1.0"
   - name: OMP_NUM_THREADS
     value: "1"
   - name: TF_NUM_INTEROP_THREADS


### PR DESCRIPTION
- Remove downloading model to docker image, models will be downloaded from model server when deploying inference module.
- Update helm charts default env to support new model design, the model informations will be obtained from model info server.