### PR TITLE
cnap: fix the inference info in pipeline table and fix cleanup

### DIFF
--- a/cnap/core/pipeline.py
+++ b/cnap/core/pipeline.py
@@ -26,8 +26,7 @@ class Pipeline:
     Attributes:
         _id (str): The pipeline ID.
         _provider (StreamProvider): The stream provider of pipeline.
-        _info_engine_info (InferenceInfo): The inference engine inforamtion of pipeline.
-        _infer_fps (dict): A dictonary that saves the inference fps for every inference service. 
+        _infer_engine_dict (dict): The dict of inference engines inforamtion of pipeline.
     """
 
     def __init__(self, provider: StreamProvider, infer_engine_info: InferenceInfo):
@@ -42,8 +41,8 @@ class Pipeline:
         """
         self._id = None
         self._provider = provider
-        self._info_engine_info = infer_engine_info
-        self._infer_fps = {}
+        self._infer_engine_dict = {infer_engine_info.id: {'infer_info': dict(infer_engine_info),
+                                                         'infer_fps': 0}}
 
     @property
     def id(self) -> str:
@@ -60,8 +59,7 @@ class Pipeline:
     def __iter__(self) -> Iterator[Tuple[str, Dict[str, Any]]]:
         """The Iterator for Pipeline class."""
         yield 'provider', dict(self._provider)
-        yield 'info_engine_info', dict(self._info_engine_info)
-        yield 'infer_fps', self._infer_fps
+        yield 'infer_engine_dict', self._infer_engine_dict
 
 
 class PipelineManager:
@@ -116,11 +114,12 @@ class PipelineManager:
         LOG.debug("Unregister Pipeline: %s", pipeline_id)
         self._db.del_table_object(PipelineManager.PIPELINE_TABLE, pipeline_id)
 
-    def set_infer_fps(self, pipeline_id: str, infer_info_id: str, infer_fps: int) -> None:
+    def set_infer_fps(self, pipeline_id: str, infer_info: InferenceInfo, infer_fps: int) -> None:
         """Set inference fps for a pipeline.
 
         Args:
             pipeline_id (str): The id of pipeline to set inference fps.
+            infer_info (InferenceInfo): The inference info to set inference fps.
             infer_fps (int): The inference fps to set.
 
         Raises:
@@ -128,11 +127,16 @@ class PipelineManager:
                 or `save_table_object_dict` if some cases are met.
         """
         LOG.debug("Set inference fps: %d for pipeline: %s and inference service: %s",
-                  infer_fps, pipeline_id, infer_info_id)
+                  infer_fps, pipeline_id, infer_info.id)
         if self._db.check_table_object_exist(PipelineManager.PIPELINE_TABLE, pipeline_id):
             pipeline_dict = self._db.get_table_object_dict(PipelineManager.PIPELINE_TABLE,
                                                            pipeline_id)
-            pipeline_dict['infer_fps'][infer_info_id] = infer_fps
+            # Add inference engine to infer_engine_dict if not exist.
+            if infer_info.id not in pipeline_dict['infer_engine_dict']:
+                pipeline_dict['infer_engine_dict'][infer_info.id] = {'infer_info': dict(infer_info),
+                                                                     'infer_fps': infer_fps}
+            else:
+                pipeline_dict['infer_engine_dict'][infer_info.id]['infer_fps'] = infer_fps
             self._db.save_table_object_dict(
                 PipelineManager.PIPELINE_TABLE,
                 pipeline_id,
@@ -140,3 +144,22 @@ class PipelineManager:
                 )
         else:
             LOG.debug("Pipeline: %s has been unregistered.", pipeline_id)
+
+    def clean_infer_engine(self, infer_info_id: str) -> None:
+        """Clean inference engine in infer_engine_dict.
+
+        Args:
+            infer_info_id (str): The id of inference info to clear inference fps.
+
+        Raises:
+            ValueError: Propagates the ValueError raised by `get_all_table_objects_dict`
+                or `save_table_object_dict` if some cases are met.
+        """
+        pipeline_dicts = self._db.get_all_table_objects_dict(PipelineManager.PIPELINE_TABLE)
+        for pipeline_id, pipeline_dict in pipeline_dicts.items():
+            del pipeline_dict['infer_engine_dict'][infer_info_id]
+            self._db.save_table_object_dict(
+                PipelineManager.PIPELINE_TABLE,
+                pipeline_id,
+                pipeline_dict
+                )

--- a/cnap/userv/inference.py
+++ b/cnap/userv/inference.py
@@ -299,6 +299,9 @@ class InferenceService(MicroAppBase):
         self._is_stopping = True
         LOG.debug("cleanup")
 
+        if self.pipeline_manager:
+            self.pipeline_manager.clean_infer_engine(self.infer_info.id)
+
         if self.infer_queue_connector:
             self.infer_queue_connector.unregister_infer_queue(self.infer_info.queue_topic)
 
@@ -437,7 +440,7 @@ class InferenceTask(MicroServiceTask):
             elapsed_time (float): The elapsed time to calculate FPS.
         """
         infer_fps_pipeline = round(self.infer_frame_count[pipeline_id] / elapsed_time)
-        self.pipeline_manager.set_infer_fps(pipeline_id, self.infer_info.id, infer_fps_pipeline)
+        self.pipeline_manager.set_infer_fps(pipeline_id, self.infer_info, infer_fps_pipeline)
 
         infer_fps_sum = round(self.infer_frame_count_sum / elapsed_time)
         drop_fps_sum = round(self.drop_frame_count_sum / elapsed_time)

--- a/cnap/userv/pipeline_server.py
+++ b/cnap/userv/pipeline_server.py
@@ -109,15 +109,17 @@ class PipelineService:
         pipelines = []
 
         for pipeline_id, pipeline_dict in pipeline_dicts.items():
-            infer_id = pipeline_dict['info_engine_info']['id']
-            pipeline = {
-                'pipeline_id': pipeline_id,
-                'model_name': inference_dicts[infer_id]['model']['details']['name'],
-                'stream_name': pipeline_dict['provider']['name'],
-                'input_fps': pipeline_dict['provider']['fps'],
-                'infer_fps': sum(pipeline_dict['infer_fps'].values())
-            }
-            pipelines.append(pipeline)
+            for infer_id in pipeline_dict['infer_engine_dict'].keys():
+                pipeline = {
+                    'pipeline_id': pipeline_id,
+                    'model_name': inference_dicts[infer_id]['model']['details']['name'],
+                    'stream_name': pipeline_dict['provider']['name'],
+                    'input_fps': pipeline_dict['provider']['fps'],
+                    'infer_fps': sum(value['infer_fps'] 
+                                      for value in pipeline_dict['infer_engine_dict'].values())
+                }
+                pipelines.append(pipeline)
+                break
 
         return pipelines
 

--- a/cnap/userv/uapp.py
+++ b/cnap/userv/uapp.py
@@ -191,6 +191,6 @@ class MicroAppBase(ABC):
 
     def stop(self):
         """Stop an application instance."""
-        self.cleanup()
         MicroServiceTask.stop_all_tasks()
         MicroServiceTask.wait_all_tasks_end()
+        self.cleanup()


### PR DESCRIPTION
This PR is to fix wrong infer fps display on SPA and wrong inference info in pipeline table when scale up/down the replicas of inference service.
- modify infer_engine_info to infer_engine_dict in pipeline table
- add inference engine to pipeline table when set fps for the first time
- cleanup after wait_all_tasks_end in MicroAppBase
- add clean_infer_engine in the cleanup of inference service