### PR TITLE
infereng.py: add the cpu-amx accelerator

### DIFF
--- a/cnap/core/infereng.py
+++ b/cnap/core/infereng.py
@@ -45,7 +45,7 @@ DEFAULT_INPUT_HEIGHT = 240
 INFER_ENGINE_TABLE = "InferEngine-table"
 
 # Set of valid devices
-VALID_DEVICES = {"cpu", "gpu", "tpu"}
+VALID_DEVICES = {"cpu", "cpu-amx", "gpu", "tpu"}
 
 class InferenceInfo:
     """Inference information class.


### PR DESCRIPTION
This PR is to add the device type for CPU-AMX.