### PR TITLE
cnap: small fixes for inference and websocket server

### DIFF
--- a/cnap/core/pipeline.py
+++ b/cnap/core/pipeline.py
@@ -136,9 +136,9 @@ class PipelineManager:
         """
         LOG.debug("Set inference fps: %d for pipeline: %s and inference service: %s",
                   infer_fps, pipeline_id, infer_info.id)
-        if self._db.check_table_object_exist(PipelineManager.PIPELINE_TABLE, pipeline_id):
-            try:
-                self._db.lock(f"{self.PIPELINE_TABLE}-lock")
+        try:
+            self._db.lock(f"{self.PIPELINE_TABLE}-lock")
+            if self._db.check_table_object_exist(PipelineManager.PIPELINE_TABLE, pipeline_id):
                 pipeline_dict = self._db.get_table_object_dict(PipelineManager.PIPELINE_TABLE,
                                                             pipeline_id)
                 # Add inference engine to infer_engine_dict if not exist.
@@ -153,10 +153,10 @@ class PipelineManager:
                     pipeline_id,
                     pipeline_dict
                     )
-            finally:
-                self._db.unlock()
-        else:
-            LOG.debug("Pipeline: %s has been unregistered.", pipeline_id)
+            else:
+                LOG.debug("Pipeline: %s has been unregistered.", pipeline_id)
+        finally:
+            self._db.unlock()
 
     def clean_infer_engine(self, infer_info_id: str) -> None:
         """Clean inference engine in infer_engine_dict.

--- a/cnap/userv/websocket_server.py
+++ b/cnap/userv/websocket_server.py
@@ -49,9 +49,9 @@ class StreamWebSocketServer:
             "STREAM_BROKER_REDIS_HOST", "127.0.0.1")
         self._stream_broker_redis_port = self._get_env(
             "STREAM_BROKER_REDIS_PORT", 6379)
-        self._ws_send_time_out = self._get_env(
+        self._ws_send_time_out = float(self._get_env(
             "WS_SEND_TIME_OUT", 10.0
-        )
+        ))
         self._pipelines = {}
         self._users = {}
 


### PR DESCRIPTION
- lock the entire set fps function
- convert the send_time_out variable of wss to float