### PR TITLE
postprocessor.py: fix NumPy array issue when using latest opencv release

### DIFF
--- a/cnap/core/processors/postprocessor.py
+++ b/cnap/core/processors/postprocessor.py
@@ -74,6 +74,7 @@ class ObjectDetectionPostprocessor(Postprocessor):
         Postprocess the output by drawing boxes and labels on the input frame for
         object detection.
         """
+        frame = frame.copy()
         try:
             if self._drawing.get('draw_boxes'):
                 boxes = outputs['detection_boxes']
@@ -121,6 +122,7 @@ class FaceRecognitionPostprocessor(Postprocessor):
         Postprocess the output by drawing boxes and labels on the input frame for
         object detection.
         """
+        frame = frame.copy()
         try:
             if self._drawing.get('draw_landmarks'):
                 facial_landmarks = outputs['facial_landmarks']


### PR DESCRIPTION
This PR is to fix the NumPy array marked as readonly issue in `postprocessor.py` when using the latest opencv release.

When using the latest opencv release, the `postprocess` function in `postprocessor.py` will raise, thus causing the inference service crash:
```
RuntimeError: Error during postprocessing: OpenCV(4.9.0) :-1: error: (-5:Bad argument) in function 'rectangle'
> Overload resolution failed:
>  - img marked as output argument, but provided NumPy array marked as readonly
>  - Expected Ptr<cv::UMat> for argument 'img'
>  - img marked as output argument, but provided NumPy array marked as readonly
>  - Expected Ptr<cv::UMat> for argument 'img'
```
This is related to the opencv patch https://github.com/opencv/opencv/pull/24026 which fixed https://github.com/opencv/opencv-python/issues/859.

We need to set the WRITEABLE flag of `frame` array to true before `cv2.rectangle`, and the flag cannot be successfully set by using `setflags` function, which will raise`ValueError: cannot set WRITEABLE flag to True of this array`
So we use `frame = frame.copy()` to set WRITEABLE flag.